### PR TITLE
Added common logging, settings, translations and jsonRPC boilerplate

### DIFF
--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -8,3 +8,6 @@
 6. Read [this info](http://kodi.wiki/view/Add-on_structure#icon.png) and drop an icon for your addon into the `resource` folder and name it `icon.png`.
 7. Read [this](http://kodi.wiki/view/Add-on_structure#fanart.jpg) and drop a addon background into the `resource` folder and name it `fanart.jpg`.
 8. End up with a beautiful Kodi addon! Good for you :) Maybe you want to [share it with us](http://kodi.wiki/view/Submitting_Add-on_updates_on_Github)?
+
+### Debugging
+To get the debug logging to work, just set the global kodi logging to true and the debug logging in your addons settings.

--- a/generators/app/templates/addon.xml
+++ b/generators/app/templates/addon.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="<%= props.scriptid %>" name="<%= props.scriptname %>" version="0.0.1" provider-name="<%= props.authors %>">
     <requires>
-        <import addon="xbmc.python" version="<%= props.kodiVersion %>"/><% if (props.type == 'Plugin') { -%><import addon="script.module.routing" version="0.2.0"/><% } -%>
+        <import addon="xbmc.python" version="<%= props.kodiVersion %>"/>
+<%_ if (props.type == 'Plugin') { -%>        <import addon="script.module.routing" version="0.2.0"/><% } %>
+<%_ if (props.type == 'Plugin' || props.type == 'Script' || props.type == 'Service') { -%>        <import addon="script.module.simplejson" version="3.3.0"/><% } %>
     </requires>
     <% if (props.type == 'Contextmenu') { -%><extension point="kodi.context.item" library="context.py">
     <item>

--- a/generators/app/templates/addon.xml
+++ b/generators/app/templates/addon.xml
@@ -3,7 +3,7 @@
     <requires>
         <import addon="xbmc.python" version="<%= props.kodiVersion %>"/>
 <%_ if (props.type == 'Plugin') { -%>        <import addon="script.module.routing" version="0.2.0"/><% } %>
-<%_ if (props.type == 'Plugin' || props.type == 'Script' || props.type == 'Service') { -%>        <import addon="script.module.simplejson" version="3.3.0"/><% } %>
+<%_ if (props.kodiVersion == '2.24.0' && (props.type == 'Plugin' || props.type == 'Script' || props.type == 'Service')) { -%>        <import addon="script.module.simplejson" version="3.3.0"/><% } %>
     </requires>
     <% if (props.type == 'Contextmenu') { -%><extension point="kodi.context.item" library="context.py">
     <item>

--- a/generators/app/templates/plugin.py
+++ b/generators/app/templates/plugin.py
@@ -8,7 +8,8 @@ from xbmcgui import ListItem
 from xbmcplugin import addDirectoryItem, endOfDirectory
 
 
-logger = logging.getLogger(__name__)
+ADDON = xbmcaddon.Addon()
+logger = logging.getLogger(ADDON.getAddonInfo('id'))
 kodiLogging.config()
 plugin = routing.Plugin()
 

--- a/generators/app/templates/plugin.py
+++ b/generators/app/templates/plugin.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import routing
+import logging
+from resources.lib import utilities
+from resources.lib import kodiLogging
 from xbmcgui import ListItem
 from xbmcplugin import addDirectoryItem, endOfDirectory
 
+
+logger = logging.getLogger(__name__)
+kodiLogging.config()
 plugin = routing.Plugin()
 
 @plugin.route('/')

--- a/generators/app/templates/resources/language/resource.language.en_gb/strings.po
+++ b/generators/app/templates/resources/language/resource.language.en_gb/strings.po
@@ -21,3 +21,7 @@ msgstr ""
 msgctxt "#32000"
 msgid "Example"
 msgstr ""
+
+msgctxt "#32001"
+msgid "Debug"
+msgstr ""

--- a/generators/app/templates/resources/lib/kodiLogging.py
+++ b/generators/app/templates/resources/lib/kodiLogging.py
@@ -1,19 +1,4 @@
 # -*- coding: utf-8 -*-
-#
-# Copyright (C) 2015 Thomas Amland
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 from resources.lib.utilities import getSettingAsBool

--- a/generators/app/templates/resources/lib/kodiLogging.py
+++ b/generators/app/templates/resources/lib/kodiLogging.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 Thomas Amland
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from resources.lib.utilities import getSettingAsBool
+
+import logging
+import xbmc
+import xbmcaddon
+
+
+class KodiLogHandler(logging.StreamHandler):
+
+    def __init__(self):
+        logging.StreamHandler.__init__(self)
+        addon_id = xbmcaddon.Addon().getAddonInfo('id')
+        prefix = b"[%s] " % addon_id
+        formatter = logging.Formatter(prefix + b'%(name)s: %(message)s')
+        self.setFormatter(formatter)
+
+    def emit(self, record):
+        levels = {
+            logging.CRITICAL: xbmc.LOGFATAL,
+            logging.ERROR: xbmc.LOGERROR,
+            logging.WARNING: xbmc.LOGWARNING,
+            logging.INFO: xbmc.LOGINFO,
+            logging.DEBUG: xbmc.LOGDEBUG,
+            logging.NOTSET: xbmc.LOGNONE,
+        }
+        if getSettingAsBool('debug'):
+            try:
+                xbmc.log(self.format(record), levels[record.levelno])
+            except UnicodeEncodeError:
+                xbmc.log(self.format(record).encode('utf-8', 'ignore'), levels[record.levelno])
+
+    def flush(self):
+        pass
+
+def config():
+    logger = logging.getLogger()
+    logger.addHandler(KodiLogHandler())
+    logger.setLevel(logging.DEBUG)

--- a/generators/app/templates/resources/lib/utilities.py
+++ b/generators/app/templates/resources/lib/utilities.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+import xbmc
+import xbmcaddon
+import re
+import sys
+import logging
+
+
+if sys.version_info >= (2, 7):
+    import json as json
+else:
+    import simplejson as json
+
+# read settings
+ADDON = xbmcaddon.Addon('<%= props.scriptid %>')
+
+logger = logging.getLogger(__name__)
+
+def notification(header, message, time=5000, icon=ADDON.getAddonInfo('icon')):
+    xbmc.executebuiltin("XBMC.Notification(%s,%s,%i,%s)" % (header, message, time, icon))
+
+def showSettings():
+    ADDON.openSettings()
+
+def getSetting(setting):
+    return ADDON.getSetting(setting).strip().decode('utf-8')
+
+def setSetting(setting, value):
+    ADDON.setSetting(setting, str(value))
+
+def getSettingAsBool(setting):
+    return getSetting(setting).lower() == "true"
+
+def getSettingAsFloat(setting):
+    try:
+        return float(getSetting(setting))
+    except ValueError:
+        return 0
+
+def getSettingAsInt(setting):
+    try:
+        return int(getSettingAsFloat(setting))
+    except ValueError:
+        return 0
+
+def getString(string_id):
+    return ADDON.getLocalizedString(string_id).encode('utf-8', 'ignore')
+
+def kodiJsonRequest(params):
+    data = json.dumps(params)
+    request = xbmc.executeJSONRPC(data)
+
+    try:
+        response = json.loads(request)
+    except UnicodeDecodeError:
+        response = json.loads(request.decode('utf-8', 'ignore'))
+
+    try:
+        if 'result' in response:
+            return response['result']
+        return None
+    except KeyError:
+        logger.warn("[%s] %s" % (params['method'], response['error']['message']))
+        return None

--- a/generators/app/templates/resources/lib/utilities.py
+++ b/generators/app/templates/resources/lib/utilities.py
@@ -6,11 +6,14 @@ import re
 import sys
 import logging
 
-
+<%_ if (props.kodiVersion == '2.24.0') { -%>
 if sys.version_info >= (2, 7):
     import json as json
 else:
     import simplejson as json
+<%_ } else { -%>
+import json as json
+<% } %>
 
 # read settings
 ADDON = xbmcaddon.Addon('<%= props.scriptid %>')

--- a/generators/app/templates/resources/lib/utilities.py
+++ b/generators/app/templates/resources/lib/utilities.py
@@ -20,8 +20,8 @@ ADDON = xbmcaddon.Addon()
 
 logger = logging.getLogger(__name__)
 
-def notification(header, message, time=5000, icon=ADDON.getAddonInfo('icon')):
-    xbmc.executebuiltin("XBMC.Notification(%s,%s,%i,%s)" % (header, message, time, icon))
+def notification(header, message, time=5000, icon=ADDON.getAddonInfo('icon'), sound=True):
+    xbmcgui.Dialog().notification(header, message, icon, time, sound)
 
 def showSettings():
     ADDON.openSettings()

--- a/generators/app/templates/resources/lib/utilities.py
+++ b/generators/app/templates/resources/lib/utilities.py
@@ -16,7 +16,7 @@ import json as json
 <% } %>
 
 # read settings
-ADDON = xbmcaddon.Addon('<%= props.scriptid %>')
+ADDON = xbmcaddon.Addon()
 
 logger = logging.getLogger(__name__)
 

--- a/generators/app/templates/resources/settings.xml
+++ b/generators/app/templates/resources/settings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
+    <setting id="debug" type="bool" label="32001" default="false"/>
 </settings>
 

--- a/generators/app/templates/script.py
+++ b/generators/app/templates/script.py
@@ -13,8 +13,7 @@ kodiLogging.config()
 
 # Put your code here, this is just an example showing
 # a textbox as soon as this addon gets called
-addon = xbmcaddon.Addon()
-addonname = addon.getAddonInfo('name')
+addonname = ADDON.getAddonInfo('name')
 
 line1 = "Hello World!"
 

--- a/generators/app/templates/script.py
+++ b/generators/app/templates/script.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from resources.lib import utilities
+from resources.lib import kodiLogging
+import logging
 import xbmcaddon
 import xbmcgui
+
+
+logger = logging.getLogger(__name__)
+kodiLogging.config()
 
 # Put your code here, this is just an example showing
 # a textbox as soon as this addon gets called

--- a/generators/app/templates/script.py
+++ b/generators/app/templates/script.py
@@ -7,7 +7,8 @@ import xbmcaddon
 import xbmcgui
 
 
-logger = logging.getLogger(__name__)
+ADDON = xbmcaddon.Addon()
+logger = logging.getLogger(ADDON.getAddonInfo('id'))
 kodiLogging.config()
 
 # Put your code here, this is just an example showing

--- a/generators/app/templates/service.py
+++ b/generators/app/templates/service.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from resources.lib import utilities
+from resources.lib import kodiLogging
+import logging
 import time
 import xbmc
+
+
+kodiLogging.config()
+logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
     monitor = xbmc.Monitor()
@@ -11,4 +18,4 @@ if __name__ == '__main__':
         if monitor.waitForAbort(10):
             # Abort was requested while waiting. We should exit
             break
-        xbmc.log("hello addon! %s" % time.time(), level=xbmc.LOGDEBUG)
+        logger.debug("hello addon! %s" % time.time())

--- a/generators/app/templates/service.py
+++ b/generators/app/templates/service.py
@@ -7,8 +7,9 @@ import time
 import xbmc
 
 
+ADDON = xbmcaddon.Addon()
+logger = logging.getLogger(ADDON.getAddonInfo('id'))
 kodiLogging.config()
-logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
     monitor = xbmc.Monitor()

--- a/test/app.js
+++ b/test/app.js
@@ -40,6 +40,8 @@ describe('generate contextmenu', function () {
       'tests/README.md',
       'resources/__init__.py',
       'resources/lib/__init__.py',
+      'resources/lib/utilities.py',
+      'resources/lib/kodiLogging.py',
       'resources/lib/README.md',
       'resources/settings.xml'
     ]);
@@ -90,6 +92,8 @@ describe('generate module', function () {
       'resources/language/resource.language.en_gb/strings.po',
       'resources/language/README.md',
       'resources/lib/__init__.py',
+      'resources/lib/utilities.py',
+      'resources/lib/kodiLogging.py',
       'resources/lib/README.md',
       'resources/settings.xml'
     ]);
@@ -135,6 +139,8 @@ describe('generate plugin', function () {
       'resources/language/resource.language.en_gb/strings.po',
       'resources/language/README.md',
       'resources/lib/__init__.py',
+      'resources/lib/utilities.py',
+      'resources/lib/kodiLogging.py',
       'resources/lib/README.md',
       'resources/settings.xml',
       'LICENSE'
@@ -153,6 +159,7 @@ describe('generate plugin', function () {
     assert.fileContent('addon.xml', '<import addon="xbmc.python" version="2.25.0"/>');
     assert.fileContent('addon.xml', '<provides>video</provides>');
     assert.fileContent('addon.xml', '<import addon="script.module.routing" version="');
+    assert.fileContent('addon.xml', '<import addon="script.module.simplejson" version="');
   });
 });
 
@@ -194,6 +201,8 @@ describe('generate resource', function () {
       'resources/language/resource.language.en_gb/strings.po',
       'resources/language/README.md',
       'resources/lib/__init__.py',
+      'resources/lib/utilities.py',
+      'resources/lib/kodiLogging.py',
       'resources/lib/README.md',
       'resources/settings.xml'
     ]);
@@ -239,6 +248,8 @@ describe('generate script', function () {
       'resources/language/resource.language.en_gb/strings.po',
       'resources/language/README.md',
       'resources/lib/__init__.py',
+      'resources/lib/utilities.py',
+      'resources/lib/kodiLogging.py',
       'resources/lib/README.md',
       'resources/settings.xml',
       'LICENSE'
@@ -257,6 +268,7 @@ describe('generate script', function () {
     assert.fileContent('addon.xml', '<platform>all</platform>');
     assert.fileContent('addon.xml', '<import addon="xbmc.python" version="2.25.0"/>');
     assert.fileContent('addon.xml', '<provides>executable</provides>');
+    assert.fileContent('addon.xml', '<import addon="script.module.simplejson" version="');
   });
 });
 
@@ -292,6 +304,8 @@ describe('generate service', function () {
       'resources/language/resource.language.en_gb/strings.po',
       'resources/language/README.md',
       'resources/lib/__init__.py',
+      'resources/lib/utilities.py',
+      'resources/lib/kodiLogging.py',
       'resources/lib/README.md',
       'resources/settings.xml',
       'LICENSE'
@@ -310,5 +324,6 @@ describe('generate service', function () {
     assert.fileContent('addon.xml', ' provider-name="Me">');
     assert.fileContent('addon.xml', '<platform>all</platform>');
     assert.fileContent('addon.xml', '<import addon="xbmc.python" version="2.25.0"/>');
+    assert.fileContent('addon.xml', '<import addon="script.module.simplejson" version="');
   });
 });

--- a/test/app.js
+++ b/test/app.js
@@ -159,7 +159,8 @@ describe('generate plugin', function () {
     assert.fileContent('addon.xml', '<import addon="xbmc.python" version="2.25.0"/>');
     assert.fileContent('addon.xml', '<provides>video</provides>');
     assert.fileContent('addon.xml', '<import addon="script.module.routing" version="');
-    assert.fileContent('addon.xml', '<import addon="script.module.simplejson" version="');
+    assert.noFileContent('addon.xml', '<import addon="script.module.simplejson" version="');
+    assert.noFileContent('resources/lib/utilities.py', 'import simplejson as json');
   });
 });
 
@@ -268,7 +269,8 @@ describe('generate script', function () {
     assert.fileContent('addon.xml', '<platform>all</platform>');
     assert.fileContent('addon.xml', '<import addon="xbmc.python" version="2.25.0"/>');
     assert.fileContent('addon.xml', '<provides>executable</provides>');
-    assert.fileContent('addon.xml', '<import addon="script.module.simplejson" version="');
+    assert.noFileContent('addon.xml', '<import addon="script.module.simplejson" version="');
+    assert.noFileContent('resources/lib/utilities.py', 'import simplejson as json');
   });
 });
 
@@ -324,6 +326,33 @@ describe('generate service', function () {
     assert.fileContent('addon.xml', ' provider-name="Me">');
     assert.fileContent('addon.xml', '<platform>all</platform>');
     assert.fileContent('addon.xml', '<import addon="xbmc.python" version="2.25.0"/>');
+    assert.noFileContent('addon.xml', '<import addon="script.module.simplejson" version="');
+    assert.noFileContent('resources/lib/utilities.py', 'import simplejson as json');
+  });
+});
+
+describe('check simplejson for jarvis', function () {
+  before(function () {
+    return helpers.run(path.join(__dirname, '../generators/app'))
+      .withPrompts({
+        type: 'Service',
+        scriptid: 'service.test',
+        start: 'login',
+        scriptname: 'My service name',
+        kodiVersion: '2.24.0',
+        platforms: 'all',
+        license: 'MIT',
+        authors: 'Me',
+        summary: 'My summary',
+        authorName: 'My real name',
+        email: 'test@test.de',
+        website: 'www.kodi.tv'
+      })
+      .toPromise();
+  });
+
+  it('check service addon.xml content', function () {
     assert.fileContent('addon.xml', '<import addon="script.module.simplejson" version="');
+    assert.fileContent('resources/lib/utilities.py', 'import simplejson as json');
   });
 });


### PR DESCRIPTION
This adds a bunch of boilerplate for plugins, services and scripts.
Only the service example will use something from this (logging).

This code is taken from my trakt script.
With the logging stuff taken from @tamland 

Please review and let me know if there are things to improve @enen92 @phil65 @phate89 