### PR TITLE
Missing `xbmcgui` import in kodiutils.py

### DIFF
--- a/generators/app/templates/resources/lib/kodiutils.py
+++ b/generators/app/templates/resources/lib/kodiutils.py
@@ -3,7 +3,6 @@
 import xbmc
 import xbmcaddon
 import xbmcgui
-import re
 import sys
 import logging
 <%_ if (props.kodiVersion == '2.24.0') { -%>

--- a/generators/app/templates/resources/lib/kodiutils.py
+++ b/generators/app/templates/resources/lib/kodiutils.py
@@ -2,6 +2,7 @@
 
 import xbmc
 import xbmcaddon
+import xbmcgui
 import re
 import sys
 import logging


### PR DESCRIPTION
`xbmcgui` import is missing despite being used by the notification method. Also re is defined there but not used.