### PR TITLE
Fix generated plugins after ReusePython PR merge

### DIFF
--- a/generators/app/templates/main.py
+++ b/generators/app/templates/main.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+import logging
+<%_ if (props.type == 'Plugin') { -%>
+import sys
+<% } %>
 
 from resources.lib import kodilogging
 <%_ if (props.type == 'Contextmenu') { -%>
@@ -12,9 +16,8 @@ from resources.lib import service
 <%_ } else if (props.type == 'Subtitle') { -%>
 from resources.lib import subtitle
 <% } %>
-import logging
-import xbmcaddon
 
+import xbmcaddon
 # Keep this file to a minimum, as Kodi
 # doesn't keep a compiled copy of this
 ADDON = xbmcaddon.Addon()
@@ -23,7 +26,7 @@ kodilogging.config()
 <%_ if (props.type == 'Contextmenu') { -%>
 context.run()
 <%_ } else if (props.type == 'Plugin') { -%>
-plugin.run()
+plugin.run(argv=sys.argv)
 <%_ } else if (props.type == 'Script') { -%>
 script.show_dialog()
 <%_ } else if (props.type == 'Service') { -%>

--- a/generators/app/templates/resources/lib/plugin.py
+++ b/generators/app/templates/resources/lib/plugin.py
@@ -30,5 +30,5 @@ def show_category(category_id):
         plugin.handle, "", ListItem("Hello category %s!" % category_id))
     endOfDirectory(plugin.handle)
 
-def run():
-    plugin.run()
+def run(argv):
+    plugin.run(argv=argv)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-kodi-addon",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Creates the basic structure for a kodi addon, written in python.",
   "homepage": "https://github.com/xbmc/generator-kodi-addon#installation",
   "author": {


### PR DESCRIPTION
Introduced by https://github.com/xbmc/xbmc/pull/13814, since the python interpreter is reused we need to propagate sys.argv from the entrypoint to the plugin file