### PR TITLE
Made Python 3 compatible

### DIFF
--- a/generators/app/templates/resources/language/resource.language.en_gb/strings.po
+++ b/generators/app/templates/resources/language/resource.language.en_gb/strings.po
@@ -16,8 +16,6 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#This is a comment
-
 msgctxt "#32000"
 msgid "Example"
 msgstr ""

--- a/generators/app/templates/resources/lib/kodilogging.py
+++ b/generators/app/templates/resources/lib/kodilogging.py
@@ -12,9 +12,8 @@ class KodiLogHandler(logging.StreamHandler):
 
     def __init__(self):
         logging.StreamHandler.__init__(self)
-        addon_id = xbmcaddon.Addon().getAddonInfo('id')
-        prefix = b"[%s] " % addon_id
-        formatter = logging.Formatter(prefix + b'%(name)s: %(message)s')
+        addon_id = xbmcaddon.Addon().getAddonInfo("id")
+        formatter = logging.Formatter("[{}] %(name)s %(message)s".format(addon_id))
         self.setFormatter(formatter)
 
     def emit(self, record):

--- a/generators/app/templates/resources/lib/kodiutils.py
+++ b/generators/app/templates/resources/lib/kodiutils.py
@@ -37,19 +37,19 @@ def set_setting(setting, value):
 
 
 def get_setting_as_bool(setting):
-    return get_setting(setting).lower() == "true"
+    return ADDON.getSettingBool(setting)
 
 
 def get_setting_as_float(setting):
     try:
-        return float(get_setting(setting))
+        return ADDON.getSettingNumber(setting)
     except ValueError:
         return 0
 
 
 def get_setting_as_int(setting):
     try:
-        return int(get_setting_as_float(setting))
+        return ADDON.getSettingInt(setting)
     except ValueError:
         return 0
 
@@ -72,6 +72,5 @@ def kodi_json_request(params):
             return response['result']
         return None
     except KeyError:
-        logger.warn("[%s] %s" %
-                    (params['method'], response['error']['message']))
+        logger.warn("[{}] {}".format(params['method'], response['error']['message']))
         return None


### PR DESCRIPTION
1. A couple of quick string formatting changes to make the output Python 3 compatible. 
2. Removed the comment in strings.po so that Travis doesn't complain when an add-on is PR'd into the main repo.
3. Switched to using the applicable getSetting[Type] methods in the helpers. 

Hope that is all OK and makes sense, basically just a few tiny things that make any new add-on compatible with Leia and above.
